### PR TITLE
Change c-a-m-o test to check for role by prefixes

### DIFF
--- a/pkg/e2e/operators/configurealertmanager.go
+++ b/pkg/e2e/operators/configurealertmanager.go
@@ -24,22 +24,14 @@ var _ = ginkgo.Describe(configureAlertManagerOperators, func() {
 
 	var clusterRoleBindings = []string{}
 
-	var roleBindings = []string{
-		"configure-alertmanager-operator",
-	}
-
-	var roles = []string{
-		"configure-alertmanager-operator",
-	}
-
 	h := helper.New()
 	checkClusterServiceVersion(h, operatorNamespace, operatorName)
 	checkConfigMapLockfile(h, operatorNamespace, operatorLockFile)
 	checkDeployment(h, operatorNamespace, operatorName, defaultDesiredReplicas)
 	checkClusterRoles(h, clusterRoles, true)
 	checkClusterRoleBindings(h, clusterRoleBindings, true)
-	checkRole(h, operatorNamespace, roles)
-	checkRoleBindings(h, operatorNamespace, roleBindings)
+	checkRolesWithNamePrefix(h, operatorNamespace, operatorName, 2)
+	checkRoleBindingsWithNamePrefix(h, operatorNamespace, operatorName, 2)
 	checkUpgrade(helper.New(), "openshift-monitoring", "configure-alertmanager-operator",
 		"configure-alertmanager-operator", "configure-alertmanager-operator-registry")
 })

--- a/pkg/e2e/operators/operators.go
+++ b/pkg/e2e/operators/operators.go
@@ -130,6 +130,37 @@ func checkRole(h *helper.H, namespace string, roles []string) {
 
 }
 
+func checkRolesWithNamePrefix(h *helper.H, namespace string, prefix string, count int) {
+	ginkgo.Context("roles with prefix", func() {
+		ginkgo.It("should exist", func() {
+			rolesList, err := h.Kube().RbacV1().Roles(namespace).List(context.TODO(), metav1.ListOptions{})
+			Expect(err).NotTo(HaveOccurred(), "failed to get roles in namespace %s", namespace)
+			var roleCount int
+			for _, r := range rolesList.Items {
+				if strings.HasPrefix(r.Name, prefix) {
+					roleCount++
+				}
+			}
+			Expect(roleCount).To(BeNumerically(">=", count))
+		}, viper.GetFloat64(config.Tests.PollingTimeout))
+	})
+}
+
+func checkRoleBindingsWithNamePrefix(h *helper.H, namespace string, prefix string, count int) {
+	ginkgo.Context("roles with prefix", func() {
+		ginkgo.It("should exist", func() {
+			roleBindings, err := h.Kube().RbacV1().RoleBindings(namespace).List(context.TODO(), metav1.ListOptions{})
+			Expect(err).NotTo(HaveOccurred(), "failed to get roles in namespace %s", namespace)
+			var roleCount int
+			for _, r := range roleBindings.Items {
+				if strings.HasPrefix(r.Name, prefix) {
+					roleCount++
+				}
+			}
+			Expect(roleCount).To(BeNumerically(">=", count))
+		}, viper.GetFloat64(config.Tests.PollingTimeout))
+	})
+}
 func checkRoleBindings(h *helper.H, namespace string, roleBindings []string) {
 	// Check that deployed rolebindings exist
 	ginkgo.Context("roleBindings", func() {


### PR DESCRIPTION
The `ClusterServiceVersion` for the `configure-alertmanager-operator` now contains the roles for the operator as part of the `permissions` field. This means that the name of the `Role` and the `RoleBinding` are not fixed but are prefixed with the CSV name. This PR changes the test so that the roles and role bindings are verified in the same namespace based only on the prefix.